### PR TITLE
Update EndOfMapVote.cs

### DIFF
--- a/Features/EndOfMapVote.cs
+++ b/Features/EndOfMapVote.cs
@@ -45,13 +45,13 @@ namespace cs2_rockthevote
 
         bool CheckMaxRounds()
         {
-            //Server.PrintToChatAll($"Remaining rounds {_maxRounds.RemainingRounds}, remaining wins: {_maxRounds.RemainingWins}, triggerBefore {_config.TriggerRoundsBeforeEnd}");
+            // Prevent triggering vote too early
+            if (_gameRules.TotalRoundsPlayed < 5) // This line is a newly added safeguard
+                return false;
             if (_maxRounds.UnlimitedRounds)
                 return false;
-
             if (_maxRounds.RemainingRounds <= _config.TriggerRoundsBeforeEnd)
                 return true;
-
             return _maxRounds.CanClinch && _maxRounds.RemainingWins <= _config.TriggerRoundsBeforeEnd;
         }
 


### PR DESCRIPTION
To prevent early voting in the initial stages of the game, a check for rounds less than 5 was added to EndOfMapVote.