### PR TITLE
Fix null NextLevel

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -26,7 +26,6 @@ namespace cs2_rockthevote
         public bool HideHudAfterVote { get; set; }
         public int ExtendTimeStep { get; set; }
         public int ExtendRoundStep { get; set; }
-        public bool PauseMatchWhenVote { get; set; } 
 
     }
 
@@ -80,7 +79,6 @@ namespace cs2_rockthevote
         public int ExtendTimeStep { get; set; } = 15;
         public int ExtendRoundStep { get; set; } = 5;
         public int ExtendLimit { get; set; } = 3;
-        public bool PauseMatchWhenVote { get; set; } = false;
 
     }
 

--- a/Config.cs
+++ b/Config.cs
@@ -24,8 +24,9 @@ namespace cs2_rockthevote
         public int VoteDuration { get; set; }
         public bool HudMenu { get; set; }
         public bool HideHudAfterVote { get; set; }
-        public int ExtendTimeStep { get; set; } 
+        public int ExtendTimeStep { get; set; }
         public int ExtendRoundStep { get; set; }
+        public bool PauseMatchWhenVote { get; set; } 
 
     }
 
@@ -57,6 +58,7 @@ namespace cs2_rockthevote
         public int ExtendRoundStep { get; set; } = 5;
         public int VotePercentage { get; set; } = 60;
         public int ExtendLimit { get; set; } = 3;
+        public bool PauseMatchWhenVote { get; set; } = false;
     }
 
     public class RtvConfig : ICommandConfig, IVoteConfig, IEndOfMapConfig, IExtendMapConfig
@@ -75,9 +77,10 @@ namespace cs2_rockthevote
         public bool DontChangeRtv { get; set; } = true;
         public bool IgnoreSpec { get; set; } = true;
         public int VoteCooldownTime { get; set; } = 300;
-        public int ExtendTimeStep { get; set; } = 15; 
+        public int ExtendTimeStep { get; set; } = 15;
         public int ExtendRoundStep { get; set; } = 5;
         public int ExtendLimit { get; set; } = 3;
+        public bool PauseMatchWhenVote { get; set; } = false;
 
     }
 

--- a/Core/ChangeMapManager.cs
+++ b/Core/ChangeMapManager.cs
@@ -89,6 +89,7 @@ namespace cs2_rockthevote
 #if DEBUG
                     _plugin?.Logger.LogInformation($"ChangeMapManager: Executing changelevel command for {map.Name}");
 #endif
+                    Server.ExecuteCommand($"nextlevel {map.Name}"); // Better to be safe if nextlevel somehow will be still null
                     Server.ExecuteCommand($"changelevel {map.Name}");
                 }
                 else if (map.Id is not null)
@@ -96,6 +97,7 @@ namespace cs2_rockthevote
 #if DEBUG
                     _plugin?.Logger.LogInformation($"ChangeMapManager: Executing host_workshop_map command for map ID {map.Id}");
 #endif                                           
+                    Server.ExecuteCommand($"nextlevel {map.Name}");  // Better to be safe if nextlevel somehow will be still null
                     Server.ExecuteCommand($"host_workshop_map {map.Id}");
                 }
                 else
@@ -103,6 +105,7 @@ namespace cs2_rockthevote
 #if DEBUG
                     _plugin?.Logger.LogInformation($"ChangeMapManager: Executing ds_workshop_changelevel command for {map.Name}");
 #endif
+                    Server.ExecuteCommand($"nextlevel {map.Name}");  // Better to be safe if nextlevel somehow will be still null
                     Server.ExecuteCommand($"ds_workshop_changelevel {map.Name}");
                 }
             });

--- a/Core/ChangeMapManager.cs
+++ b/Core/ChangeMapManager.cs
@@ -97,7 +97,7 @@ namespace cs2_rockthevote
 #if DEBUG
                     _plugin?.Logger.LogInformation($"ChangeMapManager: Executing host_workshop_map command for map ID {map.Id}");
 #endif                                           
-                    Server.ExecuteCommand($"nextlevel {map.Name}");  // Better to be safe if nextlevel somehow will be still null
+                    //Server.ExecuteCommand($"nextlevel {map.Name}");  // Better to be safe if nextlevel somehow will be still null
                     Server.ExecuteCommand($"host_workshop_map {map.Id}");
                 }
                 else

--- a/Core/EndMapVoteManager.cs
+++ b/Core/EndMapVoteManager.cs
@@ -349,7 +349,7 @@ namespace cs2_rockthevote
                 _plugin?.Logger.LogInformation("EndVote: Reset EofVoteHappening to false in finally block");
                 _plugin?.Logger.LogInformation($"Additionaly setting nextlevel to winner: {winner.Key}");
 #endif
-                if (_config!.PauseMatchWhenVote)
+                if (_plugin!.Config.EndOfMapVote.PauseMatchWhenVote)
                 {
                     Server.ExecuteCommand("mp_unpause_match");
                 }
@@ -399,7 +399,7 @@ namespace cs2_rockthevote
                 _config = config;
 
 
-                if (_config!.PauseMatchWhenVote)
+                if (_plugin!.Config.EndOfMapVote.PauseMatchWhenVote)
                 {
 #if DEBUG
                     _plugin?.Logger.LogWarning("Execute mp_pause_match");

--- a/Core/EndMapVoteManager.cs
+++ b/Core/EndMapVoteManager.cs
@@ -59,7 +59,7 @@ namespace cs2_rockthevote
 
         Dictionary<string, int> Votes = new();
         Dictionary<CCSPlayerController, string> PlayerVotes = new();
-        int timeLeft = -1;
+        public int timeLeft = -1;
 
         List<string> mapsEllected = new();
 
@@ -74,6 +74,7 @@ namespace cs2_rockthevote
 
         public bool VoteInProgress => timeLeft >= 0;
 
+        private KeyValuePair<string, int> winner;
         public void OnLoad(Plugin plugin)
         {
             _plugin = plugin;
@@ -113,6 +114,7 @@ namespace cs2_rockthevote
 
         public void MapVoted(CCSPlayerController player, string mapName)
         {
+            Server.PrintToChatAll("Chuj");
             if (_config!.HideHudAfterVote)
                 _voted.Add(player.UserId!.Value);
 
@@ -170,6 +172,7 @@ namespace cs2_rockthevote
                 menu.AddMenuOption(_localizer.Localize("general.extend-current-map"), (player, option) =>
                 {
                     MapVoted(player, _localizer.Localize("general.extend-current-map"));
+                    //Server.PrintToChatAll("Zaglosowales 1");
                     MenuManager.CloseActiveMenu(player);
                 });
             }
@@ -187,6 +190,7 @@ namespace cs2_rockthevote
                 menu.AddMenuOption(map, (player, option) =>
                 {
                     MapVoted(player, map);
+                    Server.PrintToChatAll("Zaglosowales 2");
                     MenuManager.CloseActiveMenu(player);
                 });
             }
@@ -258,7 +262,7 @@ namespace cs2_rockthevote
                 decimal maxVotes = Votes.Select(x => x.Value).Max();
                 IEnumerable<KeyValuePair<string, int>> potentialWinners = Votes.Where(x => x.Value == maxVotes);
                 Random rnd = new();
-                KeyValuePair<string, int> winner = potentialWinners.ElementAt(rnd.Next(0, potentialWinners.Count()));
+                winner = potentialWinners.ElementAt(rnd.Next(0, potentialWinners.Count()));
 
                 decimal totalVotes = Votes.Select(x => x.Value).Sum();
                 decimal percent = totalVotes > 0 ? winner.Value / totalVotes * 100M : 0;
@@ -346,7 +350,9 @@ namespace cs2_rockthevote
                 _pluginState.EofVoteHappening = false;
 #if DEBUG
                 _plugin?.Logger.LogInformation("EndVote: Reset EofVoteHappening to false in finally block");
+                _plugin?.Logger.LogInformation($"Additionaly setting nextlevel to winner: {winner.Key}");
 #endif
+                Server.ExecuteCommand($"nextlevel {winner.Key}");
             }
         }
 

--- a/Core/EndMapVoteManager.cs
+++ b/Core/EndMapVoteManager.cs
@@ -114,7 +114,6 @@ namespace cs2_rockthevote
 
         public void MapVoted(CCSPlayerController player, string mapName)
         {
-            Server.PrintToChatAll("Chuj");
             if (_config!.HideHudAfterVote)
                 _voted.Add(player.UserId!.Value);
 
@@ -172,7 +171,6 @@ namespace cs2_rockthevote
                 menu.AddMenuOption(_localizer.Localize("general.extend-current-map"), (player, option) =>
                 {
                     MapVoted(player, _localizer.Localize("general.extend-current-map"));
-                    //Server.PrintToChatAll("Zaglosowales 1");
                     MenuManager.CloseActiveMenu(player);
                 });
             }
@@ -190,7 +188,6 @@ namespace cs2_rockthevote
                 menu.AddMenuOption(map, (player, option) =>
                 {
                     MapVoted(player, map);
-                    Server.PrintToChatAll("Zaglosowales 2");
                     MenuManager.CloseActiveMenu(player);
                 });
             }
@@ -352,6 +349,11 @@ namespace cs2_rockthevote
                 _plugin?.Logger.LogInformation("EndVote: Reset EofVoteHappening to false in finally block");
                 _plugin?.Logger.LogInformation($"Additionaly setting nextlevel to winner: {winner.Key}");
 #endif
+                if (_config!.PauseMatchWhenVote)
+                {
+                    Server.ExecuteCommand("mp_unpause_match");
+                }
+
                 Server.ExecuteCommand($"nextlevel {winner.Key}");
             }
         }
@@ -382,6 +384,7 @@ namespace cs2_rockthevote
                     return;
                 }
 
+
                 Votes.Clear();
                 PlayerVotes.Clear();
                 _voted.Clear();
@@ -394,6 +397,15 @@ namespace cs2_rockthevote
                 _plugin?.Logger.LogInformation("StartVote: Set EofVoteHappening to true at start of vote");
 #endif
                 _config = config;
+
+
+                if (_config!.PauseMatchWhenVote)
+                {
+#if DEBUG
+                    _plugin?.Logger.LogWarning("Execute mp_pause_match");
+#endif
+                    Server.ExecuteCommand("mp_pause_match");
+                }
 
 
                 var mapsScrambled = Shuffle(new Random(),

--- a/Features/EndOfMapVote.cs
+++ b/Features/EndOfMapVote.cs
@@ -19,7 +19,6 @@ namespace cs2_rockthevote
         private GameRules _gameRules;
         private EndMapVoteManager _voteManager;
 
-        private ChangeMapManager _changeMapManager;
         private EndOfMapConfig _config = new();
         private Timer? _timer;
         private bool deathMatch => _gameMode?.GetPrimitiveValue<int>() == 2 && _gameType?.GetPrimitiveValue<int>() == 1;
@@ -27,7 +26,7 @@ namespace cs2_rockthevote
         private ConVar? _gameMode;
 
         // overload for multilang support
-        public EndOfMapVote(StringLocalizer localizer, TimeLimitManager timeLimit, MaxRoundsManager maxRounds, PluginState pluginState, GameRules gameRules, EndMapVoteManager voteManager, ChangeMapManager changeMapManager)
+        public EndOfMapVote(StringLocalizer localizer, TimeLimitManager timeLimit, MaxRoundsManager maxRounds, PluginState pluginState, GameRules gameRules, EndMapVoteManager voteManager)
         {
             _localizer = localizer;
             _timeLimit = timeLimit;
@@ -35,9 +34,8 @@ namespace cs2_rockthevote
             _pluginState = pluginState;
             _gameRules = gameRules;
             _voteManager = voteManager;
-            _changeMapManager = changeMapManager;
         }
-        public EndOfMapVote(TimeLimitManager timeLimit, MaxRoundsManager maxRounds, PluginState pluginState, GameRules gameRules, EndMapVoteManager voteManager, ChangeMapManager changeMapManager)
+        public EndOfMapVote(TimeLimitManager timeLimit, MaxRoundsManager maxRounds, PluginState pluginState, GameRules gameRules, EndMapVoteManager voteManager)
         {
             //_localizer = new StringLocalizer();
             _timeLimit = timeLimit;
@@ -45,7 +43,6 @@ namespace cs2_rockthevote
             _pluginState = pluginState;
             _gameRules = gameRules;
             _voteManager = voteManager;
-            _changeMapManager = changeMapManager;
         }
 
         bool CheckMaxRounds()


### PR DESCRIPTION
- Probably fixed null nextlevel so it wont randomly change map to null even on custom gamemode (and I think without gamemode_servers.txt as well),
- Added a RegisterEventHandler for EventCsWinPanelMatch so when match is ended and voting is still going it will automatically end voting and select a next map,
- Added a really small feature that will execute server command: `mp_pause_match` for EndOfMapVote when enabled in config, When EndOfMapVote is ended it executes `mp_unpause_match`.

Plugin was tested only with bots so I am not sure if everything is perfect but when tested seemed okay.